### PR TITLE
Update from update/NikitaSkrynnik/cmd-registry-memory

### DIFF
--- a/apps/registry-memory/registry-memory.yaml
+++ b/apps/registry-memory/registry-memory.yaml
@@ -16,7 +16,7 @@ spec:
         "spiffe.io/spiffe-id": "true"
     spec:
       containers:
-        - image: ghcr.io/networkservicemesh/ci/cmd-registry-memory:b0f13c8
+        - image: ghcr.io/networkservicemesh/ci/cmd-registry-memory:1b76e1e
           env:
             - name: SPIFFE_ENDPOINT_SOCKET
               value: unix:///run/spire/sockets/agent.sock


### PR DESCRIPTION
Update go.mod and go.sum to latest version from NikitaSkrynnik/cmd-registry-memory@main
PR link: https://github.com/NikitaSkrynnik/cmd-registry-memory/pull/12
Commit: 1b76e1e
Author: Nikita Skrynnik
Date: 2023-07-13 19:00:28 +1100
Message:
  - Update go.mod and go.sum to latest version from NikitaSkrynnik/sdk@main